### PR TITLE
v0.2.1: add split_confirm parameter to bypass interactive prompt in c…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: opennemr
 Type: Package
 Title: Access to the OpenElectricity API via R
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(
   person("Ryan", "Batchelor", role = c("aut", "cre"), email = "ryanbatchelor87@gmail.com"))
 Maintainer: Ryan Batchelor <ryanbatchelor87@gmail.com>

--- a/R/oe_get_network_data.R
+++ b/R/oe_get_network_data.R
@@ -18,6 +18,7 @@
 #' @param secondary_grouping Character. Secondary grouping for data aggregation. Default: NULL.
 #' @param with_clerk Logical. Include clerk data in response. Default: TRUE.
 #' @param api_key Character. OpenElectricity API key. If NULL, uses OPEN_ELECTRICITY_API_KEY environment variable. Default: NULL.
+#' @param split_confirm Logical. If TRUE (default), prompts for user confirmation before making multiple chunked API calls when the date range exceeds the API limit. Set to FALSE to proceed automatically without prompting, which is useful for programmatic/non-interactive use. Default: TRUE.
 #'
 #' @return Data frame with columns:
 #' \describe{
@@ -75,7 +76,8 @@ oe_get_network_data <- function(network_code,
                                 primary_grouping = "network",
                                 secondary_grouping = NULL,
                                 with_clerk = TRUE,
-                                api_key = NULL
+                                api_key = NULL,
+                                split_confirm = TRUE
                                 ){
 
   # Validate required inputs and dependencies
@@ -174,13 +176,15 @@ oe_get_network_data <- function(network_code,
     if (limit_info$exceeds) {
       message(glue::glue("You have asked for a duration that exceeds the standard limit for the '{interval}' interval ({limit_info$max_days_desc}).
 This will require {limit_info$n_chunks} separate API calls."))
-      if (!interactive()) {
-        stop("Date range exceeds API limit. Reduce the date range or make multiple requests manually.")
-      }
-      response <- readline("Would you like to proceed? (y/n): ")
-      if (tolower(trimws(response)) != "y") {
-        message("Request cancelled.")
-        return(invisible(NULL))
+      if (split_confirm) {
+        if (!interactive()) {
+          stop("Date range exceeds API limit. Reduce the date range or make multiple requests manually.")
+        }
+        response <- readline("Would you like to proceed? (y/n): ")
+        if (tolower(trimws(response)) != "y") {
+          message("Request cancelled.")
+          return(invisible(NULL))
+        }
       }
       message(glue::glue("Making {limit_info$n_chunks} API calls..."))
       results <- lapply(seq_along(limit_info$chunks), function(i) {
@@ -198,7 +202,8 @@ This will require {limit_info$n_chunks} separate API calls."))
           primary_grouping  = primary_grouping,
           secondary_grouping = secondary_grouping,
           with_clerk        = with_clerk,
-          api_key           = api_key
+          api_key           = api_key,
+          split_confirm     = split_confirm
         )
       })
       return(do.call(rbind, results))

--- a/R/oe_get_network_market_data.R
+++ b/R/oe_get_network_market_data.R
@@ -16,6 +16,7 @@
 #' @param primary_grouping Character. Primary grouping for data aggregation. Valid values: "network", "network_region". Default: "network".
 #' @param with_clerk Logical. Include clerk data in response. Default: TRUE.
 #' @param api_key Character. OpenElectricity API key. If NULL, uses OPEN_ELECTRICITY_API_KEY environment variable. Default: NULL.
+#' @param split_confirm Logical. If TRUE (default), prompts for user confirmation before making multiple chunked API calls when the date range exceeds the API limit. Set to FALSE to proceed automatically without prompting, which is useful for programmatic/non-interactive use. Default: TRUE.
 #'
 #' @return Data frame with columns:
 #' \describe{
@@ -80,7 +81,8 @@ oe_get_network_market_data <- function(network_code,
                                         network_region = NULL,
                                         primary_grouping = "network",
                                         with_clerk = TRUE,
-                                        api_key = NULL) {
+                                        api_key = NULL,
+                                        split_confirm = TRUE) {
 
   # Validate required inputs
   if (missing(network_code) || is.null(network_code)) {
@@ -138,13 +140,15 @@ oe_get_network_market_data <- function(network_code,
     if (limit_info$exceeds) {
       message(glue::glue("You have asked for a duration that exceeds the standard limit for the '{interval}' interval ({limit_info$max_days_desc}).
 This will require {limit_info$n_chunks} separate API calls."))
-      if (!interactive()) {
-        stop("Date range exceeds API limit. Reduce the date range or make multiple requests manually.")
-      }
-      response <- readline("Would you like to proceed? (y/n): ")
-      if (tolower(trimws(response)) != "y") {
-        message("Request cancelled.")
-        return(invisible(NULL))
+      if (split_confirm) {
+        if (!interactive()) {
+          stop("Date range exceeds API limit. Reduce the date range or make multiple requests manually.")
+        }
+        response <- readline("Would you like to proceed? (y/n): ")
+        if (tolower(trimws(response)) != "y") {
+          message("Request cancelled.")
+          return(invisible(NULL))
+        }
       }
       message(glue::glue("Making {limit_info$n_chunks} API calls..."))
       results <- lapply(seq_along(limit_info$chunks), function(i) {
@@ -159,7 +163,8 @@ This will require {limit_info$n_chunks} separate API calls."))
           network_region    = network_region,
           primary_grouping  = primary_grouping,
           with_clerk        = with_clerk,
-          api_key           = api_key
+          api_key           = api_key,
+          split_confirm     = split_confirm
         )
       })
       return(do.call(rbind, results))

--- a/man/oe_get_network_data.Rd
+++ b/man/oe_get_network_data.Rd
@@ -16,7 +16,8 @@ oe_get_network_data(
   primary_grouping = "network",
   secondary_grouping = NULL,
   with_clerk = TRUE,
-  api_key = NULL
+  api_key = NULL,
+  split_confirm = TRUE
 )
 }
 \arguments{
@@ -44,6 +45,8 @@ Note: "AEMO_ROOFTOP" and "APVI" are not supported by this endpoint (API returns 
 \item{with_clerk}{Logical. Include clerk data in response. Default: TRUE.}
 
 \item{api_key}{Character. OpenElectricity API key. If NULL, uses OPEN_ELECTRICITY_API_KEY environment variable. Default: NULL.}
+
+\item{split_confirm}{Logical. If TRUE (default), prompts for user confirmation before making multiple chunked API calls when the date range exceeds the API limit. Set to FALSE to proceed automatically without prompting, which is useful for programmatic/non-interactive use. Default: TRUE.}
 }
 \value{
 Data frame with columns:

--- a/man/oe_get_network_market_data.Rd
+++ b/man/oe_get_network_market_data.Rd
@@ -13,7 +13,8 @@ oe_get_network_market_data(
   network_region = NULL,
   primary_grouping = "network",
   with_clerk = TRUE,
-  api_key = NULL
+  api_key = NULL,
+  split_confirm = TRUE
 )
 }
 \arguments{
@@ -36,6 +37,8 @@ Note: "market_value" is listed in the API docs but returns a 400 error as of API
 \item{with_clerk}{Logical. Include clerk data in response. Default: TRUE.}
 
 \item{api_key}{Character. OpenElectricity API key. If NULL, uses OPEN_ELECTRICITY_API_KEY environment variable. Default: NULL.}
+
+\item{split_confirm}{Logical. If TRUE (default), prompts for user confirmation before making multiple chunked API calls when the date range exceeds the API limit. Set to FALSE to proceed automatically without prompting, which is useful for programmatic/non-interactive use. Default: TRUE.}
 }
 \value{
 Data frame with columns:


### PR DESCRIPTION
…hunked API calls

Adds `split_confirm = TRUE` parameter to `oe_get_network_data()` and `oe_get_network_market_data()`. When set to FALSE, large date ranges are automatically split into chunked API calls without prompting the user, enabling programmatic and non-interactive use.